### PR TITLE
ci: GitHub Actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,31 @@
+on:
+  - push
+  - pull_request
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-13
+        go:
+          - '1.11'
+          - '1.12'
+          - '1.13'
+          - '1.14'
+          - '1.15'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+      - run: make
+      - name: Upload the build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: goformat-${{ matrix.os }}-${{ matrix.go }}
+          path: bin/


### PR DESCRIPTION
Close #3 

Instead of migrating to newer versions of Go, compiling the existing code in the CI environment yields standalone executables that worked.

Example: https://github.com/liyishuai/goformat/actions/runs/11696340179

Artifacts tested runnable in Linux.